### PR TITLE
Exclude nodejs global packages installed from `npm install -g`

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -73,6 +73,7 @@ comm -13 \
   -wholename '/var/spool' -prune -o \
   -wholename '/etc/NetworkManager/system-connections' -prune -o \
   -wholename '/var/db/sudo' -prune -o \
+  \( -wholename '/usr/lib/node_modules*' -and -not -wholename '/usr/lib/node_modules/npm*' \) -o \
   -wholename '/var/tmp' -prune \) | sort -u \
   ) | sed -e 's|^\t||;'
 


### PR DESCRIPTION
Many nodejs users may have global packages ( [express](https://github.com/visionmedia/express), etc ) installed in system.

This patch excludes directory `/usr/lib/node_modules` except for the pre-installed package npm in `/usr/lib/node_modules/npm`.
