### PR TITLE
Various additional files to exclude

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -62,6 +62,7 @@ comm -13 \
   -wholename '/etc/ssl' -prune -o \
   -wholename '/etc/xml/catalog' -prune -o \
   -wholename '/etc/systemd/system' -prune -o \
+  -wholename '/etc/systemd/network' -prune -o \
   -wholename '/etc/udev/rules.d/70-digitalocean-net.rules' -prune -o \
   -wholename '/etc/vconsole.conf' -prune -o \
   -wholename '/home' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -49,6 +49,7 @@ comm -13 \
   -wholename '/etc/ld.so.cache' -prune -o \
   -wholename '/etc/machine-id' -prune -o \
   -wholename '/etc/network.d/ethernet-static' -prune -o \
+  -wholename '/etc/os-release' -prune -o\
   -wholename '/etc/passwd' -prune -o \
   -wholename '/etc/passwd-' -prune -o \
   -wholename '/etc/passwd.OLD' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -29,6 +29,7 @@ comm -13 \
   -wholename '/boot/EFI' -prune -o \
   -wholename '/boot/initramfs-linux*' -prune -o \
   -wholename '/dev' -prune -o \
+  -wholename '/etc/.pwd.lock' -o \
   -wholename '/etc/.updated' -prune -o \
   -wholename '/etc/ca-certificates' -prune -o \
   -wholename '/etc/conf.d' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -63,6 +63,7 @@ comm -13 \
   -wholename '/etc/xml/catalog' -prune -o \
   -wholename '/etc/systemd/system' -prune -o \
   -wholename '/etc/udev/rules.d/70-digitalocean-net.rules' -prune -o \
+  -wholename '/etc/vconsole.conf' -prune -o \
   -wholename '/home' -prune -o \
   -wholename '/lost+found' -prune -o \
   -wholename '/media' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -29,6 +29,7 @@ comm -13 \
   -wholename '/boot/EFI' -prune -o \
   -wholename '/boot/initramfs-linux*' -prune -o \
   -wholename '/dev' -prune -o \
+  -wholename '/etc/.updated' -prune -o \
   -wholename '/etc/ca-certificates' -prune -o \
   -wholename '/etc/conf.d' -prune -o \
   -wholename '/etc/pacman.d/gnupg' -prune -o \
@@ -74,6 +75,7 @@ comm -13 \
   -wholename '/usr/share/info/dir' -prune -o \
   -wholename '/usr/share/backintime' -prune -o \
   -wholename '/usr/share/mime' -prune -o \
+  -wholename '/var/.updated' -prune -o \
   -wholename '/var/abs' -prune -o \
   -wholename '/var/cache' -prune -o \
   -wholename '/var/lock' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -49,7 +49,7 @@ comm -13 \
   -wholename '/etc/ld.so.cache' -prune -o \
   -wholename '/etc/machine-id' -prune -o \
   -wholename '/etc/network.d/ethernet-static' -prune -o \
-  -wholename '/etc/os-release' -prune -o\
+  -wholename '/etc/os-release' -prune -o \
   -wholename '/etc/passwd' -prune -o \
   -wholename '/etc/passwd-' -prune -o \
   -wholename '/etc/passwd.OLD' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -39,8 +39,10 @@ comm -13 \
   -wholename '/etc/fancontrol' -prune -o \
   -wholename '/etc/gshadow' -prune -o \
   -wholename '/etc/gshadow-' -prune -o \
+  -wholename '/etc/gshadow.OLD' -prune -o \
   -wholename '/etc/group' -prune -o \
   -wholename '/etc/group-' -prune -o \
+  -wholename '/etc/group.OLD' -prune -o \
   -wholename '/etc/hostname' -prune -o \
   -wholename '/etc/locale.conf' -prune -o \
   -wholename '/etc/localtime' -prune -o \
@@ -49,8 +51,10 @@ comm -13 \
   -wholename '/etc/network.d/ethernet-static' -prune -o \
   -wholename '/etc/passwd' -prune -o \
   -wholename '/etc/passwd-' -prune -o \
+  -wholename '/etc/passwd.OLD' -prune -o \
   -wholename '/etc/shadow' -prune -o \
   -wholename '/etc/shadow-' -prune -o \
+  -wholename '/etc/shadow.OLD' -prune -o \
   -wholename '/etc/udev/hwdb.bin' -prune -o \
   -wholename '/etc/ssh/ssh_host*' -prune -o \
   -wholename '/etc/rc.digitalocean' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -82,6 +82,8 @@ comm -13 \
   -wholename '/usr/local/bin' -prune -o \
   -wholename '/usr/share/info/dir' -prune -o \
   -wholename '/usr/share/backintime' -prune -o \
+  -wholename '/usr/share/fonts/TTF/fonts.dir' -prune -o \
+  -wholename '/usr/share/fonts/TTF/fonts.scale' -prune -o \
   -wholename '/usr/share/mime' -prune -o \
   -wholename '/var/.updated' -prune -o \
   -wholename '/var/abs' -prune -o \


### PR DESCRIPTION
/etc/.updated & /var/.updated from systemd
/etc/.pwd.lock from kernel's lockpwdf()
.OLD files (variant of passwd- groups- shadow- and gshadow-)
/etc/os-release (owned by core/filesystem but still shows up)
/etc/vconsole.conf (console config -- keymap & font)
/etc/systemd/network (systemd-networkd config files)
/usr/share/fonts/TTF/fonts.[dir|scale]
