### PR TITLE
Exclude DKMS module folder for currently installed kernel

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -15,6 +15,9 @@
 # Usage:
 # lostfiles
 
+# get current kernel version for excluding current dkms module folder in /usr/lib/modules
+CURRENTKERNEL="$(uname -r)"
+
 if [ $UID != "0" ]; then
   echo "You must run this script as root." 1>&2
   exit 1
@@ -78,6 +81,7 @@ comm -13 \
   -wholename '/tmp' -prune -o \
   -wholename '/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack' -prune -o \
   -wholename '/usr/lib/locale/locale-archive' -prune -o \
+  -wholename '/usr/lib/modules/'$CURRENTKERNEL'' -prune -o \
   \( -wholename '/usr/lib/node_modules*' -and -not -wholename '/usr/lib/node_modules/npm*' \) -o \
   -wholename '/usr/local/bin' -prune -o \
   -wholename '/usr/share/info/dir' -prune -o \


### PR DESCRIPTION
- Add variable for current kernel version based on output from `uname -r`

- Use variable to find the DKMS module folder for current kernel to prune it from `find` output

Old DKMS module folders can be removed at the discretion of the user. Pruning `find` ouput of currently installed DKMS module folders makes it easier for the user to identify DKMS module folders located in `/usr/lib/modules` that can be safely removed if desired.