### PR TITLE
Exclude Addition files

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -32,7 +32,7 @@ comm -13 \
   -wholename '/boot/EFI' -prune -o \
   -wholename '/boot/initramfs-linux*' -prune -o \
   -wholename '/dev' -prune -o \
-  -wholename '/etc/.blkid.tab' -prune -o \
+  -wholename '/etc/blkid.tab' -prune -o \
   -wholename '/etc/.pwd.lock' -o \
   -wholename '/etc/.updated' -prune -o \
   -wholename '/etc/ca-certificates' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -32,9 +32,9 @@ comm -13 \
   -wholename '/boot/EFI' -prune -o \
   -wholename '/boot/initramfs-linux*' -prune -o \
   -wholename '/dev' -prune -o \
-  -wholename '/etc/blkid.tab' -prune -o \
   -wholename '/etc/.pwd.lock' -o \
   -wholename '/etc/.updated' -prune -o \
+  -wholename '/etc/blkid.tab' -prune -o \
   -wholename '/etc/ca-certificates' -prune -o \
   -wholename '/etc/conf.d' -prune -o \
   -wholename '/etc/dfs' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -36,6 +36,7 @@ comm -13 \
   -wholename '/etc/.updated' -prune -o \
   -wholename '/etc/ca-certificates' -prune -o \
   -wholename '/etc/conf.d' -prune -o \
+  -wholename '/etc/dfs' -prune -o \
   -wholename '/etc/pacman.d/gnupg' -prune -o \
   -wholename '/etc/adjtime' -prune -o \
   -wholename '/etc/digitalocean' -prune -o \
@@ -68,6 +69,7 @@ comm -13 \
   -wholename '/etc/systemd/network' -prune -o \
   -wholename '/etc/udev/rules.d/70-digitalocean-net.rules' -prune -o \
   -wholename '/etc/vconsole.conf' -prune -o \
+  -wholename '/etc/zfs/zpool.cache' -prune -o \
   -wholename '/home' -prune -o \
   -wholename '/lost+found' -prune -o \
   -wholename '/media' -prune -o \
@@ -90,6 +92,7 @@ comm -13 \
   -wholename '/usr/share/fonts/TTF/fonts.dir' -prune -o \
   -wholename '/usr/share/fonts/TTF/fonts.scale' -prune -o \
   -wholename '/usr/share/mime' -prune -o \
+  -wholename '/usr/var' -prune -o \
   -wholename '/usr/var/cache' -prune -o \
   -wholename '/var/.updated' -prune -o \
   -wholename '/var/abs' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -32,6 +32,7 @@ comm -13 \
   -wholename '/boot/EFI' -prune -o \
   -wholename '/boot/initramfs-linux*' -prune -o \
   -wholename '/dev' -prune -o \
+  -wholename '/etc/.blkid.tab' -prune -o \
   -wholename '/etc/.pwd.lock' -o \
   -wholename '/etc/.updated' -prune -o \
   -wholename '/etc/ca-certificates' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -95,6 +95,8 @@ comm -13 \
   -wholename '/usr/share/backintime' -prune -o \
   -wholename '/usr/share/fonts/TTF/fonts.dir' -prune -o \
   -wholename '/usr/share/fonts/TTF/fonts.scale' -prune -o \
+  -wholename '/usr/share/fonts/misc/fonts.dir' -prune -o \
+  -wholename '/usr/share/fonts/misc/fonts.scale' -prune -o \
   -wholename '/usr/share/mime' -prune -o \
   -wholename '/usr/var' -prune -o \
   -wholename '/usr/var/cache' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -63,6 +63,10 @@ comm -13 \
   -wholename '/etc/udev/hwdb.bin' -prune -o \
   -wholename '/etc/ssh/ssh_host*' -prune -o \
   -wholename '/etc/rc.digitalocean' -prune -o \
+  -wholename '/etc/samba/private/passdb.tdb' -prune -o \
+  -wholename '/etc/samba/private/secrets.tdb' -prune -o \
+  -wholename '/etc/samba/private/smbpasswd' -prune -o \
+  -wholename '/etc/samba/smb.conf' -prune -o \
   -wholename '/etc/ssl' -prune -o \
   -wholename '/etc/xml/catalog' -prune -o \
   -wholename '/etc/systemd/system' -prune -o \

--- a/lostfiles
+++ b/lostfiles
@@ -98,8 +98,8 @@ comm -13 \
   -wholename '/usr/share/fonts/misc/fonts.dir' -prune -o \
   -wholename '/usr/share/fonts/misc/fonts.scale' -prune -o \
   -wholename '/usr/share/mime' -prune -o \
-  -wholename '/usr/var' -prune -o \
   -wholename '/usr/var/cache' -prune -o \
+  -wholename '/usr/var/run' -prune -o \
   -wholename '/var/.updated' -prune -o \
   -wholename '/var/abs' -prune -o \
   -wholename '/var/cache' -prune -o \


### PR DESCRIPTION
/etc/blkid.tab - cache file from blkid
/etc/dfs - file sharing config from ZFS/SPL
/etc/samba/[various] - configs for Samba (specific files listed, not just dir)
/usr/share/fonts/misc/fonts.[dir|scale] - configs generated from fontconfig binaries
/usr/var/run - BSD's /var, from ZFS/SPL