### PR TITLE
Add /etc/dhcpcd.duid

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -40,6 +40,7 @@ comm -13 \
   -wholename '/etc/dfs' -prune -o \
   -wholename '/etc/pacman.d/gnupg' -prune -o \
   -wholename '/etc/adjtime' -prune -o \
+  -wholename '/etc/dhcpcd.duid' -prune -o \
   -wholename '/etc/digitalocean' -prune -o \
   -wholename '/etc/fancontrol' -prune -o \
   -wholename '/etc/gshadow' -prune -o \


### PR DESCRIPTION
From ArchWiki:
"The DUID value is set in /etc/dhcpcd.duid. For efficient DHCP lease
operation it is important that it is unique for the system and applies
to all network interfaces alike, while the IAID represents an identifier
for each of the systems' interfaces"