### PR TITLE
ignore snapper snapshots

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -25,6 +25,7 @@ fi
 comm -13 \
   <(pacman -Qlq | sed -e 's|/$||' | sort -u) \
   <(find / -not \( \
+  -wholename '/.snapshots' -prune -o \
   -wholename '/boot/syslinux' -prune -o \
   -wholename '/boot/grub' -prune -o \
   -wholename '/boot/loader' -prune -o \


### PR DESCRIPTION
When using snapper, lostfiles would give you a huge output because it lists all files of all snapshots. So the .snapshots directory should be ignored.