### PR TITLE
Change strict/relaxed into arrays, add support for /etc/lostfiles

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -22,145 +22,130 @@ if [ $UID != "0" ]; then
   exit 1
 fi
 
-# strict mode aims to be more verbose ignoring less
+declare -a STRICT=(
+  '/dev'
+  '/home'
+  '/lost+found'
+  '/media'
+  '/mnt'
+  '/proc'
+  '/root'
+  '/run'
+  '/scratch'
+  '/srv'
+  '/sys'
+  '/tmp'
+  '/var/.updated'
+  '/var/lock'
+  '/var/lib'
+  '/var/log'
+  '/var/run'
+  '/var/spool'
+)
 
-strict() {
-  comm -13 \
-    <(pacman -Qlq | sed -e 's|/$||' | sort -u) \
-    <(find / -not \( \
-    -wholename '/dev' -prune -o \
-    -wholename '/home' -prune -o \
-    -wholename '/lost+found' -prune -o \
-    -wholename '/media' -prune -o \
-    -wholename '/mnt' -prune -o \
-    -wholename '/proc' -prune -o \
-    -wholename '/root' -prune -o \
-    -wholename '/run' -prune -o \
-    -wholename '/scratch' -prune -o \
-    -wholename '/srv' -prune -o \
-    -wholename '/sys' -prune -o \
-    -wholename '/tmp' -prune -o \
-    -wholename '/var/.updated' -prune -o \
-    -wholename '/var/lock' -prune -o \
-    -wholename '/var/lib' -prune -o \
-    -wholename '/var/log' -prune -o \
-    -wholename '/var/run' -prune -o \
-    -wholename '/var/spool' -prune \) | sort -u \
-    ) | sed -e 's|^\t||;'
-}
+declare -a RELAXED=(
+  '/swapfile'
+  '/.snapshots'
+  '/boot/syslinux'
+  '/boot/grub'
+  '/boot/loader'
+  '/boot/EFI'
+  '/boot/initramfs-linux*'
+  '/etc/.pwd.lock'
+  '/etc/.updated'
+  '/etc/blkid.tab'
+  '/etc/ca-certificates'
+  '/etc/conf.d'
+  '/etc/dfs'
+  '/etc/pacman.d/gnupg'
+  '/etc/adjtime'
+  '/etc/dhcpcd.duid'
+  '/etc/digitalocean'
+  '/etc/fancontrol'
+  '/etc/gshadow'
+  '/etc/gshadow-'
+  '/etc/gshadow.OLD'
+  '/etc/easy-rsa'
+  '/etc/openvpn'
+  '/etc/group'
+  '/etc/group-'
+  '/etc/group.OLD'
+  '/etc/hostname'
+  '/etc/letsencrypt'
+  '/etc/locale.conf'
+  '/etc/localtime'
+  '/etc/ld.so.cache'
+  '/etc/machine-id'
+  '/etc/network.d/ethernet-static'
+  '/etc/os-release'
+  '/etc/passwd'
+  '/etc/passwd-'
+  '/etc/passwd.OLD'
+  '/etc/shadow'
+  '/etc/shadow-'
+  '/etc/shadow.OLD'
+  '/etc/udev/hwdb.bin'
+  '/etc/ssh/ssh_host*'
+  '/etc/NetworkManager/system-connections'
+  '/etc/rc.digitalocean'
+  '/etc/samba/private/passdb.tdb'
+  '/etc/samba/private/secrets.tdb'
+  '/etc/samba/private/smbpasswd'
+  '/etc/samba/smb.conf'
+  '/etc/ssl'
+  '/etc/xml/catalog'
+  '/etc/systemd/system'
+  '/etc/systemd/network'
+  '/etc/udev/rules.d/70-digitalocean-net.rules'
+  '/etc/vconsole.conf'
+  '/etc/zfs/zpool.cache'
+  '/usr/bin/__pycache__'
+  '/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack'
+  '/usr/lib/locale/locale-archive'
+  '/usr/lib/modules/'$CURRENTKERNEL''
+  '/usr/local'
+  '/usr/share/dict/words'
+  '/usr/share/info/dir'
+  '/usr/share/.mono/certs/Trust'
+  '/usr/share/applications/mimeinfo.cache'
+  '/usr/share/backintime'
+  '/usr/share/fonts/TTF/fonts.dir'
+  '/usr/share/fonts/TTF/fonts.scale'
+  '/usr/share/fonts/misc/fonts.dir'
+  '/usr/share/fonts/misc/fonts.scale'
+  '/usr/share/mime'
+  '/usr/share/webapps/owncloud/data'
+  '/usr/var/cache'
+  '/usr/var/run'
+  '/var/lost+found'
+  '/var/abs'
+  '/var/cache'
+  '/var/db/sudo'
+)
 
-# relaxed mode is more forgiving about hits
+if [ -e /etc/lostfiles ]; then
+  mapfile CONFIG < /etc/lostfiles
+fi
 
-relaxed() {
-  comm -13 \
-    <(pacman -Qlq | sed -e 's|/$||' | sort -u) \
-    <(find / -not \( \
-    -wholename '/swapfile' -prune -o \
-    -wholename '/.snapshots' -prune -o \
-    -wholename '/boot/syslinux' -prune -o \
-    -wholename '/boot/grub' -prune -o \
-    -wholename '/boot/loader' -prune -o \
-    -wholename '/boot/EFI' -prune -o \
-    -wholename '/boot/initramfs-linux*' -prune -o \
-    -wholename '/dev' -prune -o \
-    -wholename '/etc/.pwd.lock' -prune -o \
-    -wholename '/etc/.updated' -prune -o \
-    -wholename '/etc/blkid.tab' -prune -o \
-    -wholename '/etc/ca-certificates' -prune -o \
-    -wholename '/etc/conf.d' -prune -o \
-    -wholename '/etc/dfs' -prune -o \
-    -wholename '/etc/pacman.d/gnupg' -prune -o \
-    -wholename '/etc/adjtime' -prune -o \
-    -wholename '/etc/dhcpcd.duid' -prune -o \
-    -wholename '/etc/digitalocean' -prune -o \
-    -wholename '/etc/fancontrol' -prune -o \
-    -wholename '/etc/gshadow' -prune -o \
-    -wholename '/etc/gshadow-' -prune -o \
-    -wholename '/etc/gshadow.OLD' -prune -o \
-    -wholename '/etc/easy-rsa' -prune -o \
-    -wholename '/etc/openvpn' -prune -o \
-    -wholename '/etc/group' -prune -o \
-    -wholename '/etc/group-' -prune -o \
-    -wholename '/etc/group.OLD' -prune -o \
-    -wholename '/etc/hostname' -prune -o \
-    -wholename '/etc/letsencrypt' -prune -o \
-    -wholename '/etc/locale.conf' -prune -o \
-    -wholename '/etc/localtime' -prune -o \
-    -wholename '/etc/ld.so.cache' -prune -o \
-    -wholename '/etc/machine-id' -prune -o \
-    -wholename '/etc/network.d/ethernet-static' -prune -o \
-    -wholename '/etc/os-release' -prune -o \
-    -wholename '/etc/passwd' -prune -o \
-    -wholename '/etc/passwd-' -prune -o \
-    -wholename '/etc/passwd.OLD' -prune -o \
-    -wholename '/etc/shadow' -prune -o \
-    -wholename '/etc/shadow-' -prune -o \
-    -wholename '/etc/shadow.OLD' -prune -o \
-    -wholename '/etc/udev/hwdb.bin' -prune -o \
-    -wholename '/etc/ssh/ssh_host*' -prune -o \
-    -wholename '/etc/NetworkManager/system-connections' -prune -o \
-    -wholename '/etc/rc.digitalocean' -prune -o \
-    -wholename '/etc/samba/private/passdb.tdb' -prune -o \
-    -wholename '/etc/samba/private/secrets.tdb' -prune -o \
-    -wholename '/etc/samba/private/smbpasswd' -prune -o \
-    -wholename '/etc/samba/smb.conf' -prune -o \
-    -wholename '/etc/ssl' -prune -o \
-    -wholename '/etc/xml/catalog' -prune -o \
-    -wholename '/etc/systemd/system' -prune -o \
-    -wholename '/etc/systemd/network' -prune -o \
-    -wholename '/etc/udev/rules.d/70-digitalocean-net.rules' -prune -o \
-    -wholename '/etc/vconsole.conf' -prune -o \
-    -wholename '/etc/zfs/zpool.cache' -prune -o \
-    -wholename '/home' -prune -o \
-    -wholename '/lost+found' -prune -o \
-    -wholename '/media' -prune -o \
-    -wholename '/mnt' -prune -o \
-    -wholename '/proc' -prune -o \
-    -wholename '/root' -prune -o \
-    -wholename '/run' -prune -o \
-    -wholename '/scratch' -prune -o \
-    -wholename '/srv' -prune -o \
-    -wholename '/sys' -prune -o \
-    -wholename '/tmp' -prune -o \
-    -wholename '/usr/bin/__pycache__' -prune -o \
-    -wholename '/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack' -prune -o \
-    -wholename '/usr/lib/locale/locale-archive' -prune -o \
-    -wholename '/usr/lib/modules/'$CURRENTKERNEL'' -prune -o \
-    \( -wholename '/usr/lib/node_modules*' -and -not -wholename '/usr/lib/node_modules/npm/*' \) -o \
-    -wholename '/usr/local' -prune -o \
-    -wholename '/usr/share/dict/words' -prune -o \
-    -wholename '/usr/share/info/dir' -prune -o \
-    -wholename '/usr/share/.mono/certs/Trust' -prune -o \
-    -wholename '/usr/share/applications/mimeinfo.cache' -prune -o \
-    -wholename '/usr/share/backintime' -prune -o \
-    -wholename '/usr/share/fonts/TTF/fonts.dir' -prune -o \
-    -wholename '/usr/share/fonts/TTF/fonts.scale' -prune -o \
-    -wholename '/usr/share/fonts/misc/fonts.dir' -prune -o \
-    -wholename '/usr/share/fonts/misc/fonts.scale' -prune -o \
-    -wholename '/usr/share/mime' -prune -o \
-    -wholename '/usr/share/webapps/owncloud/data' -prune -o \
-    -wholename '/usr/var/cache' -prune -o \
-    -wholename '/usr/var/run' -prune -o \
-    -wholename '/var/.updated' -prune -o \
-    -wholename '/var/lost+found' -prune -o \
-    -wholename '/var/abs' -prune -o \
-    -wholename '/var/cache' -prune -o \
-    -wholename '/var/lock' -prune -o \
-    -wholename '/var/lib' -prune -o \
-    -wholename '/var/log' -prune -o \
-    -wholename '/var/run' -prune -o \
-    -wholename '/var/spool' -prune -o \
-    -wholename '/var/db/sudo' -prune -o \
-    -wholename '/var/tmp' -prune \) | sort -u \
-    ) | sed -e 's|^\t||;'
+run() {
+  CMD=""
+  for i in ${EXCLUDE[*]}
+  do
+    CMD+="-path $i -prune -o "
+  done
+
+  comm -13 <(pacman -Qlq | sed -e 's|/$||' | sort -u) <(find / -not \( ${CMD::-4} \) | sort -u ) | sed -e 's|^\t||;'
 }
 
 case "$1" in
   s|S|strict|Strict)
-    strict
+    # strict mode aims to be more verbose ignoring less
+    EXCLUDE=( "${STRICT[@]}" "${CONFIG[@]}" )
+    run
     ;;
   r|R|relaxed|Relaxed)
-    relaxed
+    EXCLUDE=( "${STRICT[@]}" "${RELAXED[@]}" "${CONFIG[@]}" )
+    run
     ;;
   *)
     echo "Usage $0 {strict|relaxed}"


### PR DESCRIPTION
Two big changes in this.

1) I've changed the two commands into one command that uses arrays. I believe this makes it easier to extend the lists of exclusions. It has an array of strict, and an array of relaxed. When run, it will either run with a combined strict and config, or a combined strict, relaxed, and config. (Note, the relaxed array doesn't contain the strict paths)

2) I've added support for /etc/lostfiles. A config file of paths (1 per line). This config will be merged into the strict or relaxed arrays and used as more exclusions.
example: 

```
$ cat /etc/lostfiles

/opt/crashplan
/var/drives
/var/shares
/opt/plexmediaserver
/opt/plexpy

```

Let me know if you'd like any changes for this to be accepted.
