### PR TITLE
ignore /boot/initramfs* and /boot/lost+found

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -61,7 +61,8 @@ relaxed() {
     -wholename '/boot/grub' -prune -o \
     -wholename '/boot/loader' -prune -o \
     -wholename '/boot/EFI' -prune -o \
-    -wholename '/boot/initramfs-linux*' -prune -o \
+    -wholename '/boot/initramfs*' -prune -o \
+    -wholename '/boot/lost+found' -prune -o \
     -wholename '/dev' -prune -o \
     -wholename '/etc/.pwd.lock' -prune -o \
     -wholename '/etc/.updated' -prune -o \


### PR DESCRIPTION
initramfs imgs isn't necessarily named "linux".
fixes #32 
Also ignores lost+found under boot. #30 