### PR TITLE
Exclude package files from various external package managers

### DIFF
--- a/lostfiles
+++ b/lostfiles
@@ -127,10 +127,13 @@ relaxed() {
     -wholename '/sys' -prune -o \
     -wholename '/tmp' -prune -o \
     -wholename '/usr/bin/__pycache__' -prune -o \
-    -wholename '/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack' -prune -o \
+    -wholename '/usr/lib/ghc-*' -prune -o \
     -wholename '/usr/lib/locale/locale-archive' -prune -o \
     -wholename '/usr/lib/modules/'$CURRENTKERNEL'' -prune -o \
     \( -wholename '/usr/lib/node_modules*' -and -not -wholename '/usr/lib/node_modules/npm/*' \) -o \
+    -wholename '/usr/lib/python*/site-packages' -prune -o \
+    -wholename '/usr/lib/ruby/gems' -prune -o \
+    -wholename '/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack' -prune -o \
     -wholename '/usr/local' -prune -o \
     -wholename '/usr/share/dict/words' -prune -o \
     -wholename '/usr/share/info/dir' -prune -o \


### PR DESCRIPTION
Added excludes for Haskell, Python and Ruby packages in relaxed mode. These files are managed by ghc-pkg, pip and gem, respectively.