### PR TITLE
Performance improvement with LC_ALL=C

### DIFF
--- a/common/lostfiles.in
+++ b/common/lostfiles.in
@@ -41,7 +41,7 @@ shift $((OPTIND -1))
 
 filter() {
   # just filter
-  sed -e 's|^\t||;'
+  sed -e 's|^\t||;' | sort
 }
 
 filter_sort() {
@@ -49,6 +49,7 @@ filter_sort() {
 }
 
 strict() {
+  export LC_ALL=C
   comm -13 \
     <(pacman -Qlq | sed -e 's|/$||' | sort -u) \
     <(find / -not \( \
@@ -70,12 +71,13 @@ strict() {
     -wholename '/var/log' -prune -o \
     -wholename '/var/run' -prune -o \
     -wholename '/var/spool' -prune \) | sort -u \
-    ) | $use_filter
+    )
 }
 
 # relaxed mode is more forgiving about hits
 
 relaxed() {
+  export LC_ALL=C
   # get current kernel version for excluding current dkms module folder in /usr/lib/modules
   CURRENTKERNEL="$(uname -r)"
 
@@ -184,14 +186,14 @@ relaxed() {
     -wholename '/var/spool' -prune -o \
     -wholename '/var/db/sudo' -prune -o \
     -wholename '/var/tmp' -prune \) | sort -u \
-    ) | $use_filter
+    )
 }
 
 
 if [[ $MODE -eq 0 ]]; then
-  relaxed
+  relaxed | $use_filter
 else
-  strict
+  strict | $use_filter
 fi
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
When I started using this script, I noticed it took about 20 seconds to do its job, which I considered normal given that it basically works loops over all files in the system.
```
[zealcharm@SOL lostfiles]$ time sudo bash common/lostfiles.in 
/
[...]

real	0m17.942s
user	0m1.061s
sys	0m0.027s
```

However, I also use to search over the whole system sometimes, and this completes in about 1 second. I also saw that while running the script, the CPU was pegged at 100%.

With some experimentation, I saw that the majority of the time was spent on comparisons and sorting, not file system access. I tried to make it faster by using `LC_ALL=C`, and the performance improvement was abysmal:
```
[zealcharm@SOL lostfiles]$ time LC_ALL=C sudo bash common/lostfiles.in
/
[...]

real	0m3.895s
user	0m0.163s
sys	0m0.022s
```

As a matter of fact, my locale is `en_US.UTF8`, not some locale that may not have been optimized.

This is my attempt at implementing the behaviour inside the program... I'm not too knowledgeable about the intricacies of Bash scripting and `LC_ALL`, so it may be completely wrong, but basically, I have attempted to set `LC_ALL=C` inside the filtering code and leave the rest as it is. I also added a call to `sort` in `filter()`, since the results of `strict()` or `relaxed()` may no longer be returned with the user's locale.