### PR TITLE
Only look where files should be

### DIFF
--- a/common/lostfiles.in
+++ b/common/lostfiles.in
@@ -52,26 +52,7 @@ strict() {
   export LC_ALL=C
   comm -13 \
     <(pacman -Qlq | sed -e 's|/$||' | sort -u) \
-    <(find / -not \( \
-    -wholename '/dev' -prune -o \
-    -wholename '/home' -prune -o \
-    -wholename '/lost+found' -prune -o \
-    -wholename '/media' -prune -o \
-    -wholename '/mnt' -prune -o \
-    -wholename '/proc' -prune -o \
-    -wholename '/root' -prune -o \
-    -wholename '/run' -prune -o \
-    -wholename '/scratch' -prune -o \
-    -wholename '/srv' -prune -o \
-    -wholename '/sys' -prune -o \
-    -wholename '/tmp' -prune -o \
-    -wholename '/var/.updated' -prune -o \
-    -wholename '/var/lock' -prune -o \
-    -wholename '/var/lib' -prune -o \
-    -wholename '/var/log' -prune -o \
-    -wholename '/var/run' -prune -o \
-    -wholename '/var/spool' -prune \) | sort -u \
-    )
+    <(find /boot /etc /opt /srv /usr /var | sort -u)
 }
 
 # relaxed mode is more forgiving about hits
@@ -83,16 +64,13 @@ relaxed() {
 
   comm -13 \
     <(pacman -Qlq | sed -e 's|/$||' | sort -u) \
-    <(find / -not \( \
-    -wholename '/swapfile' -prune -o \
-    -wholename '/.snapshots' -prune -o \
+    <(find /boot /etc /opt /usr /var -not \( \
     -wholename '/boot/syslinux' -prune -o \
     -wholename '/boot/grub' -prune -o \
     -wholename '/boot/loader' -prune -o \
     -wholename '/boot/EFI' -prune -o \
     -wholename '/boot/initramfs*' -prune -o \
     -wholename '/boot/lost+found' -prune -o \
-    -wholename '/dev' -prune -o \
     -wholename '/etc/.etckeeper' -prune -o \
     -wholename '/etc/.git' -prune -o \
     -wholename '/etc/.pwd.lock' -prune -o \
@@ -143,19 +121,7 @@ relaxed() {
     -wholename '/etc/udev/rules.d/70-digitalocean-net.rules' -prune -o \
     -wholename '/etc/vconsole.conf' -prune -o \
     -wholename '/etc/zfs/zpool.cache' -prune -o \
-    -wholename '/home' -prune -o \
-    -wholename '/incoming' -prune -o \
-    -wholename '/lost+found' -prune -o \
-    -wholename '/media' -prune -o \
-    -wholename '/mnt' -prune -o \
     -wholename '/opt/google-appengine-go/appengine/api/*.pyc' -prune -o \
-    -wholename '/proc' -prune -o \
-    -wholename '/root' -prune -o \
-    -wholename '/run' -prune -o \
-    -wholename '/scratch' -prune -o \
-    -wholename '/srv' -prune -o \
-    -wholename '/sys' -prune -o \
-    -wholename '/tmp' -prune -o \
     -wholename '/usr/bin/__pycache__' -prune -o \
     -wholename '/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack' -prune -o \
     -wholename '/usr/lib/locale/locale-archive' -prune -o \


### PR DESCRIPTION
And make the strict mode more strict (do not exclude anything under `/var`). I think strict should look every where package might install files.

This is a partial fix w.r.t. the need for the ability to add excluded folders, but should also improve performances a lot.