### PR TITLE
make: Ensure reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-bin:
 install-man:
 	@echo -e '\033[1;32mInstalling manpage...\033[0m'
 	install -Dm644 doc/$(PN).1 "$(DESTDIR)$(MANDIR)/$(PN).1"
-	gzip -9 "$(DESTDIR)$(MANDIR)/$(PN).1"
+	gzip -n9 "$(DESTDIR)$(MANDIR)/$(PN).1"
 
 uninstall:
 	$(RM) "$(DESTDIR)$(BINDIR)/$(PN)"


### PR DESCRIPTION
The -n switch doesn't embed the timestamp into the gzipped file. This
enables reproducible builds of the package.

$ diffoscope lostfiles*.pkg.tar.zst build/lostfiles*.pkg.tar.zst
lostfiles-4.03-2-any.pkg.tar.zst: 20480 bytes
build/lostfiles-4.03-2-any.pkg.tar.zst: 20480 bytes
--- lostfiles-4.03-2-any.pkg.tar.zst
+++ build/lostfiles-4.03-2-any.pkg.tar.zst
[...]
│ ├── usr/share/man/man1/lostfiles.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, was "lostfiles.1", last modified: Sun Jul  5 22:49:33 2020, max compression, from Unix
│ │ │ +gzip compressed data, was "lostfiles.1", last modified: Tue Jul  7 10:52:40 2020, max compression, from Unix

Signed-off-by: Morten Linderud <morten@linderud.pw>