### PR TITLE
Exclude /usr/lib/graphviz/config6.

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -90,6 +90,7 @@
 -/usr/bin/__pycache__
 -/usr/lib/gdk-pixbuf-2.0/*/loaders.cache
 -/usr/lib/gio/modules/giomodule.cache
+-/usr/lib/graphviz/config6
 -/usr/lib/gtk-2.0/*/immodules.cache
 -/usr/lib/gtk-3.0/*/immodules.cache
 -/usr/lib/libnetbrake.so.0


### PR DESCRIPTION
Graphviz generates this file upon installation. It contains a list of modules and is vital for graphviz to work properly.