### PR TITLE
Exclude more files by default

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -35,6 +35,8 @@
 -/etc/fltk
 -/etc/fltk/fltk.org
 -/etc/fltk/fltk.org/fltk.prefs
+-/etc/fonts/conf.d
+-/etc/fonts/local.conf
 -/etc/.git
 -/etc/group
 -/etc/group-
@@ -43,6 +45,7 @@
 -/etc/gshadow-
 -/etc/gshadow.OLD
 -/etc/hostname
+-/etc/hushlogins
 -/etc/ld.so.cache
 -/etc/letsencrypt
 -/etc/locale.conf
@@ -55,12 +58,15 @@
 -/etc/openvpn
 -/etc/os-release
 -/etc/pacman.d/gnupg
+-/etc/pacman.d/hooks
 -/etc/passwd
 -/etc/passwd-
 -/etc/passwd.OLD
 -/etc/ppp/ip-up.d/sslvpnroute.sh
 -/etc/ppp/netextender.pid
 -/etc/ppp/netextenderppp.pid
+-/etc/ppp/peers/provider
+-/etc/ppp/resolv.conf
 -/etc/ppp/sslvpn.clientip
 -/etc/printcap
 -/etc/.pwd.lock
@@ -109,6 +115,7 @@
 -/usr/share/hplip/**/__pycache__
 -/usr/share/icons/*/icon-theme.cache
 -/usr/share/info/dir
+-/usr/share/man/mandoc.db
 -/usr/share/mime
 -/usr/share/.mono
 -/usr/share/.mono/certs
@@ -122,6 +129,7 @@
 -/usr/var/run
 -/var/abs
 -/var/cache
+-/var/db/ntpd.drift
 -/var/db/sudo
 -/var/lib
 -/var/lock


### PR DESCRIPTION
I tried to avoid "niche stuff", but feel free to ask me to remove something if you want.

-/etc/fonts/conf.d — configured presets for fontconfig ([ArchWiki](https://wiki.archlinux.org/title/Font_configuration)).

-/etc/fonts/local.conf — global configuration for fontconfig ([ArchWiki](https://wiki.archlinux.org/title/Font_configuration)).

-/etc/hushlogins — default file to enable login's hushed mode system-wide ([man](https://man.archlinux.org/man/login.1)).

-/etc/pacman.d/hooks — directory for pacman's hooks ([man](https://man.archlinux.org/man/pacman.conf.5.en)).

-/etc/ppp/peers/provider — default configuration for pppd, "pon" without arguments will use it ([man](https://man.archlinux.org/man/pon.1)).

-/etc/ppp/resolv.conf — pppd will create this file if advised on ArchWiki option "usepeerdns" is enabled ([man](https://man.archlinux.org/man/core/ppp/pppd.8.en)).

-/usr/share/man/mandoc.db — database for mandoc ([man](https://man.archlinux.org/man/mandoc.db.5.en)).

-/var/db/ntpd.drift — OpenNTPD reads it on startup ([man](https://man.archlinux.org/man/ntpd.8)).