### PR TITLE
Exclude /opt/containerd

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -87,6 +87,7 @@
 -/etc/vconsole.conf
 -/etc/xml
 -/etc/zfs/zpool.cache
+-/opt/containerd
 -/opt/google-appengine-go/appengine/api/*.pyc
 -/srv
 -/usr/bin/__pycache__


### PR DESCRIPTION
It's created by containerd on startup. I think it can be excluded by default.