### PR TITLE
Exclude /etc/cni

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -21,6 +21,7 @@
 -/etc/adjtime
 -/etc/blkid.tab
 -/etc/ca-certificates
+-/etc/cni
 -/etc/conf.d
 -/etc/cups/ppd/*.ppd
 -/etc/cups/ppd/*.ppd.O


### PR DESCRIPTION
It's created by containerd. I think it can be excluded by default.