### PR TITLE
Exclude /etc/credstore

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -22,6 +22,8 @@
 -/etc/blkid.tab
 -/etc/ca-certificates
 -/etc/conf.d
+-/etc/credstore
+-/etc/credstore.encrypted
 -/etc/cups/ppd/*.ppd
 -/etc/cups/ppd/*.ppd.O
 -/etc/cups/printers.conf.O


### PR DESCRIPTION
Those files are created by systemd. I think they can be excluded by default.