### PR TITLE
Exclude /etc/subuid- and /etc/subgid-

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -79,6 +79,8 @@
 -/etc/shadow.OLD
 -/etc/ssh/ssh_host*
 -/etc/ssl
+-/etc/subgid-
+-/etc/subuid-
 -/etc/systemd/network
 -/etc/systemd/system
 -/etc/systemd/user


### PR DESCRIPTION
They're created by shadow package.
ref. https://man7.org/linux/man-pages/man5/subuid.5.html