### PR TITLE
Improve handling of kernel modules

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -145,5 +145,5 @@
 
 # exclude node modules outside of the npm subfolder
 $\( -not \( -path '/usr/lib/node_modules*' -and -not -path '/usr/lib/node_modules/npm/*' \) \)
-# exclude dkms module folder for the current kernel version in /usr/lib/modules
-$\( -not \( -path '/usr/lib/modules/'`uname -r` -prune \) \)
+# exclude dkms module folder for the kernel versions currently installed to /boot/vmlinuz-linux* in /usr/lib/modules
+$\( `for kernel in /boot/vmlinuz-linux*; do version=$(file $kernel | cut -d ' ' -f 9); echo "-not ( -path /usr/lib/modules/$version -prune )";done` \)


### PR DESCRIPTION
`uname -r` does not work if the kernel was updated without restarting, or if multiple kernels are installed. Instead, exclude all dirs with a corresponding kernel in /boot.

Also tested with zen and lts kernel installed.