### PR TITLE
Exclude /usr/lib/gconv/gconv-modules.cache

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -96,6 +96,7 @@
 -/opt/google-appengine-go/appengine/api/*.pyc
 -/srv
 -/usr/bin/__pycache__
+-/usr/lib/gconv/gconv-modules.cache
 -/usr/lib/gdk-pixbuf-2.0/*/loaders.cache
 -/usr/lib/gio/modules/giomodule.cache
 -/usr/lib/gtk-2.0/*/immodules.cache


### PR DESCRIPTION
glibc package, ref:
- https://gitlab.archlinux.org/archlinux/packaging/packages/glibc/-/merge_requests/4/diffs
- https://gitlab.archlinux.org/archlinux/packaging/packages/glibc/-/issues/8