### PR TITLE
Fix systemd .wants exclusion

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -155,8 +155,8 @@ $\( -not \( -path '/usr/lib/node_modules*' -and -not -path '/usr/lib/node_module
 # exclude dkms module folder for the kernel versions currently installed to /boot/vmlinuz-linux* in /usr/lib/modules
 $\( `for kernel in /boot/vmlinuz-linux*; do version=$(file $kernel | cut -d ' ' -f 9); echo "-not ( -path /usr/lib/modules/$version -prune )";done` \)
 
-# exclude systemd .wants directories
-$\( -not \( -type d -name '*.wants' -prune \) \)
+# exclude .wants folders under /etc/systemd
+$\( -not \( -type d -name '*.wants' -path '/etc/systemd/*' -prune \) \)
 
 # exclude symbolic links under /etc/systemd (created by systemctl enable)
 $\( -not \( -type l -path '/etc/systemd/*' -prune \) \)


### PR DESCRIPTION
@graysky2 just saw 44675dfd35b19e7637ef2ff20e07a128a8659e48

This will restrict `.wants` exclusion to `/etc/systemd`.
Previously I forgot it, sorry :(