### PR TITLE
Exclude /usr/lib/libvsscript.so

### DIFF
--- a/common/lostfiles.conf
+++ b/common/lostfiles.conf
@@ -107,6 +107,7 @@
 -/usr/lib/gtk-2.0/*/immodules.cache
 -/usr/lib/gtk-3.0/*/immodules.cache
 -/usr/lib/libnetbrake.so.0
+-/usr/lib/libvsscript.so
 -/usr/lib/locale/locale-archive
 -/usr/lib/udev/hwdb.bin
 -/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack


### PR DESCRIPTION
Part of `vapoursynth` package (required by `ffmpeg`).
Ref. https://archlinux.org/packages/extra/x86_64/vapoursynth/files/